### PR TITLE
Improved User Page + metadata

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   },
   images: {
     dangerouslyAllowSVG: true,
-    domains: ['i.seadn.io','api.reservoir.tools', 'raw.githubusercontent.com', 'blur.io', 'www.loot.exchange', 'gem.xyz', 'sudoswap.xyz', 'openseauserdata.com', 'alienswap.xyz', 'www.ens.vision'],
+    domains: ['i.seadn.io', 'api.reservoir.tools', 'raw.githubusercontent.com', 'blur.io', 'www.loot.exchange', 'gem.xyz', 'sudoswap.xyz', 'openseauserdata.com', 'alienswap.xyz', 'www.ens.vision', 'lh3.googleusercontent.com'],
   },
   webpack(config) {
     config.module.rules.push({

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -3,17 +3,26 @@ import { NextResponse, NextRequest } from "next/server";
 export async function POST(request: NextRequest) {
   const query: any = await request.json()
 
-  console.log('https://api.reservoir.tools/users/${query.address}/tokens/v6')
   try {
-    const res = await fetch(`https://api.reservoir.tools/users/${query.address}/tokens/v6`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': process.env.RESERVOIR_API_KEY || '',
-        'Access-Control-Allow-Origin': '*'
-      },
-    });
-    const data: any = await res.json()
-    return NextResponse.json(data)
+    let continuation = ""
+    const userTokens: any = []
+    do {
+      const url = `https://api.reservoir.tools/users/${query.address}/tokens/v7` + (continuation ? `?continuation=${continuation}` : "")
+      console.log(url)
+      const res = await fetch(url, {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': process.env.RESERVOIR_API_KEY || '',
+          'Access-Control-Allow-Origin': '*'
+        },
+      })
+      const data: any = await res.json()
+      userTokens.push(...data.tokens)
+      console.log()
+      continuation = data.continuation
+    } while (continuation)
+    console.log(userTokens);
+    return NextResponse.json({ tokens: userTokens })
   } catch (error) {
     return NextResponse.json({ message: 'Internal server error' })
   }

--- a/src/app/collection/[address]/[id]/page.tsx
+++ b/src/app/collection/[address]/[id]/page.tsx
@@ -9,6 +9,7 @@ import { shortenHex } from "@/functions/utils";
 import { TokenContent } from "./TokenContent";
 import { ListingModal } from "@/app/components/ListingModal";
 import { TokenAttributes } from "./TokenAttributes";
+import { Metadata } from "next";
 
 export default async function Page({
   params,

--- a/src/app/collection/[address]/page.tsx
+++ b/src/app/collection/[address]/page.tsx
@@ -1,5 +1,19 @@
 import { getData } from "@/functions";
 import { CollectionContent } from "../CollectionContent";
+import { Metadata } from "next";
+import { Collection } from "@/types";
+
+export async function generateMetadata(
+  { params }: { params: { address: string } }
+): Promise<Metadata> {
+  const collection_data = await getData({ id: params.address }, "collection");
+  const collection: Collection = collection_data.collections[0];
+
+  return {
+    title: `Atlas - Collection: ${collection.name}`,
+    description: `Collection Details and Marketplace for ${collection.name} - Created for adventurers by Bibliotheca DAO`,
+  };
+}
 
 export default async function Page({
   params,

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,9 +1,13 @@
 import { allWhiteListed } from "@/constants";
 import { getData } from "@/functions";
 import { Collection } from "@/types";
-import { formatEther } from "ethers/lib/utils.js";
 import Image from "next/image";
 import Link from "next/link";
+
+export const metadata = {
+  title: 'Atlas - Collections of the Lootverse',
+  description: 'Various collections of the Lootverse - Created for adventurers by Bibliotheca DAO'
+}
 
 export default async function Page() {
   const data = await getData(

--- a/src/app/components/UserTokenCard.tsx
+++ b/src/app/components/UserTokenCard.tsx
@@ -1,0 +1,31 @@
+import SafeImage from "@/app/components/ui/safeimage";
+import { UserTokenData } from "@/types";
+import Link from "next/link";
+
+function UserTokenCard({ token }: { token: UserTokenData }) {
+    return (
+        <div className="duration-300 transform border rounded-xl border-white/10 hover:-translate-y-1">
+            {token.token.image && (
+                <SafeImage
+                    src={token.token.image}
+                    alt={"Image for: " + token.token.name}
+                    className="mx-auto rounded-t-xl"
+                    width={400}
+                    height={400}
+                />
+            )}
+            <div className="px-3 pt-4 pb-4">
+                <div className="text-sm truncate">#{token.token.tokenId}</div>
+                <h6>{token.token.name}</h6>
+
+                <div className="flex justify-between">
+                    <Link href={`/collection/${token.token.contract}/${token.token.tokenId}`}>
+                        More
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default UserTokenCard;

--- a/src/app/components/UserTokenGrid.tsx
+++ b/src/app/components/UserTokenGrid.tsx
@@ -1,0 +1,14 @@
+import TokenInfo from "./UserTokenCard";
+import { UserTokenData } from "@/types";
+
+function UserTokenGrid({ tokens }: { tokens: UserTokenData[] }) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {tokens.map((token, index) => (
+        <TokenInfo key={index} token={token} />
+      ))}
+    </div>
+  );
+}
+
+export default UserTokenGrid;

--- a/src/app/components/ui/safeimage.tsx
+++ b/src/app/components/ui/safeimage.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React from "react";
+import Image, { ImageProps } from "next/image";
+
+import nextConfig from "../../../../next.config.js";
+
+export const isImageDomainAllowed = (src: string) => {
+    try {
+        const url = new URL(src);
+        return nextConfig.images?.domains?.includes(url.hostname);
+    } catch (error) {
+        return false;
+    }
+};
+
+const SafeImage = (props: ImageProps) => {
+
+    if (!isImageDomainAllowed(props.src as string)) {
+        return null;
+    }
+
+    return <Image {...props} />;
+};
+
+export default SafeImage;

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,5 +1,15 @@
 import { games } from "@/constants/games";
 import { Button } from "@/app/components/ui/button";
+import { Metadata } from "next";
+
+export async function generateMetadata(
+  { params }: { params: { id: string } }
+): Promise<Metadata> {
+  return {
+    title: `Atlas - Homepage for: ${params.id}`,
+    description: `Homepage for ${params.id} - Created for Adventurers by Bibliotheca DAO`
+  };
+}
 
 export default async function Page({ params }: { params: { id: string } }) {
   const game = games.find((game) => game.id === params.id);

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,10 +1,11 @@
-import { getData } from "@/functions";
-import { Collection, Game } from "@/types";
-import { formatEther } from "ethers/lib/utils.js";
-import Image from "next/image";
-import Link from "next/link";
+import { Game } from "@/types";
 import { GameCard } from "../components/GameCard";
 import { games } from "@/constants";
+
+export const metadata = {
+  title: 'Atlas - Games of the Realms',
+  description: 'Various games in the onchain world of Realms - Created for adventurers by Bibliotheca DAO'
+}
 
 export default async function Page() {
   return (

--- a/src/app/homepages/realms-adventurers/page.tsx
+++ b/src/app/homepages/realms-adventurers/page.tsx
@@ -4,6 +4,11 @@ import Overview from "./components/GameOverview";
 import EconomicDashboard from "./components/EconomicDashboard";
 import Image from "next/legacy/image";
 
+export const metadata = {
+    title: 'Atlas - Homepage for Realms: Eternum',
+    description: 'Homepage for Realms: Eternum with Game Overview and Economic Dashboard - Created for adventurers by Bibliotheca DAO'
+}
+
 export default function HomePage() {
     const game = games.find((game) => game.id === "realms-adventurers");
 

--- a/src/constants/whiteListedContracts.ts
+++ b/src/constants/whiteListedContracts.ts
@@ -47,3 +47,9 @@ export const allWhiteListed = [
     },
 ]
 
+export const customContractNames: { [index: string]: string } = {
+    "0x7afe30cb3e53dba6801aa0ea647a0ecea7cbe18d": "Realms",
+    "0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7": "Loot",
+    "0x86f7692569914b5060ef39aab99e62ec96a6ed45": "Crypts",
+    "0x527a4206ac04c2017295cf32f1fc2f9e034a7c40": "Banners"
+}

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,10 +1,11 @@
-export async function getData(query: any, route: string) {
+export async function getData(query: any, route: string, forceRefresh?: boolean) {
     const res = await fetch(process.env.NEXT_PUBLIC_LOCAL_API + route, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Origin': '*'
         },
+        cache: forceRefresh ? "no-cache" : "default",
         body: JSON.stringify(query)
     });
 
@@ -15,4 +16,4 @@ export async function getData(query: any, route: string) {
     }
 
     return await res.json();;
-} 
+}


### PR DESCRIPTION
- added tabbed view to user page (dedicated tabs for Loot contracts and then a catch-all "All" tab),
- thumbnails showed for most NFTs (some non-whitelisted image hosting domains excluded)
- modified the user token data fetching route logic to allow for iterative retrieval of all NFTs owned by an address using the continuation parameter
- added basic title/description metadata (for now) to collections, games, game homepages, user, collection details pages